### PR TITLE
Two Fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('sample_cpp_project', 'cpp',
     version : '1.0',
     license : [ 'proprietary'],
-    meson_version : '>= 0.40.1',
+    meson_version : '>= 0.50.0',
     default_options : [ 'warning_level=3', 'buildtype=debugoptimized', 'cpp_std=c++11' ]
 )
 
@@ -53,7 +53,7 @@ subdir('docs')
 # This adds the clang format file to the build directory
 configure_file(input : '.clang-format',
                output : '.clang-format',
-               configuration : configuration_data())
+	       copy: true)
 run_target('format',
   command : ['clang-format','-i','-style=file',project_sources,project_test_sources,project_benchmark_sources,project_header_files])
 
@@ -63,7 +63,7 @@ regex = '^((?!(third_party|tests|benchmarks|gtest)).)*$'
 # This adds clang tidy support
 configure_file(input : '.clang-tidy',
                output : '.clang-tidy',
-               configuration : configuration_data())
+               copy : true)
 run_target('tidy',
   command : ['run-clang-tidy.py','-fix', '-j' , '8', 'files', regex ,'-format', '-p='+ meson.build_root()])
 

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -7,4 +7,4 @@ source_hash = 94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91
 
 patch_url = https://wrapdb.mesonbuild.com/v1/projects/gtest/1.10.0/1/get_zip
 patch_filename = gtest-1.10.0-1-wrap.zip
-patch_hash = 2825db6614cb56783e88a3f4a01a8d3423fdac68c5de6cc61e5319b8607b5417
+patch_hash = 04ff14e8880e4e465f6260221e9dfd56fea6bc7cce4c4aff0dc528e4a2c8f514


### PR DESCRIPTION
1. Update Wrap for gtest.
2. Use the 'copy' keyword to copy the configuration files of `.clang-format` and `.clang-tidy`